### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["nihalxkumar"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Learnings"
 description = "This is to document my progress and to share my learnings with others who may find them helpful."


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10